### PR TITLE
Fix section counter in appendix

### DIFF
--- a/jmlr2e.sty
+++ b/jmlr2e.sty
@@ -15,6 +15,8 @@
 %     be invented.)
 %   Last edited June 17, 2019 Fabian Pedregosa
 %     Added a preprint option
+%   Last edited February 3, 2020 Boyue Li
+%     Fixed section counter in appendix
 %
 %          The name of this file should follow the article document
 %          type, e.g. \documentstyle[jmlr]{article}
@@ -345,7 +347,8 @@ are provided at \url{http://jmlr.org/papers/v#1/#6.html}.\hfill}}%
 \renewcommand{\appendix}{\par
   \setcounter{section}{0}
   \setcounter{subsection}{0}
-  \def\thesection{\Alph{section}}
+  \def\thesection{\Alph{section}}%
+  \ifdefined\theHsection \def\theHsection{\Alph{section}} \fi%
 \def\section{\@ifnextchar*{\@startsiction{section}{1}{\z@}{-0.24in}{0.10in}%
              {\large\bf\raggedright}}%
 {\@startsiction{section}{1}{\z@}{-0.24in}{0.10in}


### PR DESCRIPTION
The current style file will mess up the table of content if ```\subsection{}``` is used in appendix. The reason is the counter provided by ```hyperref``` wasn't redefined when redefining ```\appendix```.
This can be solved by loading ```hyperref``` after ```jmlr2e``` or redefining ```\theHsection```.

Compile the following minimal example
```
\documentclass{article}
\usepackage{jmlr2e}
% \usepackage[nohyperref]{jmlr2e}
% \usepackage{hyperref}

\begin{document}

\section{A}
    \subsection{B}
        \subsubsection{C}

\appendix
\section{1}
    \subsection{2}
        \subsubsection{3}

\end{document}
```
Current style file will produce:
<img width="487" alt="Screen Shot 2020-02-04 at 00 18 48" src="https://user-images.githubusercontent.com/5857249/73716323-a997b100-46e4-11ea-8d27-b98841500d71.png">

This pull request will produce:
<img width="479" alt="Screen Shot 2020-02-04 at 00 17 49" src="https://user-images.githubusercontent.com/5857249/73716322-a997b100-46e4-11ea-9695-dc6cb0cc00b4.png">