### PR TITLE
Add good increment for Example

### DIFF
--- a/jmlr2e.sty
+++ b/jmlr2e.sty
@@ -385,8 +385,8 @@ are provided at \url{http://jmlr.org/papers/v#1/#6.html}.\hfill}}%
 \else
     \newenvironment{proof}{\par\noindent{\bf Proof\ }}{\hfill\BlackBox\\[2mm]}
 \fi
-\newtheorem{example}{Example} 
 \newtheorem{theorem}{Theorem}
+\newtheorem{example}[theorem]{Example} 
 \newtheorem{lemma}[theorem]{Lemma} 
 \newtheorem{proposition}[theorem]{Proposition} 
 \newtheorem{remark}[theorem]{Remark}


### PR DESCRIPTION
When defining the environnements in the .sty file it gives :
```
\newtheorem{example}{Example}  
\newtheorem{theorem}{Theorem} 
\newtheorem{lemma}[theorem]{Lemma}  
\newtheorem{proposition}[theorem]{Proposition}  
\newtheorem{remark}[theorem]{Remark} 
\newtheorem{corollary}[theorem]{Corollary} 
\newtheorem{definition}[theorem]{Definition} 
\newtheorem{conjecture}[theorem]{Conjecture} 
\newtheorem{axiom}[theorem]{Axiom}
```
In particular the ‘‘Example'' environnement is not incremented in the same way as the ‘‘Remark''. In practice we can quickly have Remark 45 since everything is incremented but just Example 2.

This PR fixes this issue.